### PR TITLE
feat: migrate infrastructure charts to OCI and add Renovate automation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,367 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "prConcurrentLimit": 0,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/buildkit/.*-deployment\\.yaml$/"
+      ],
+      "matchStrings": [
+        "image:\\s+busybox:(?<currentValue>.+)"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "busybox"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/buildkit/.*-deployment\\.yaml$/"
+      ],
+      "matchStrings": [
+        "image:\\s+moby/buildkit:(?<currentValue>.+)"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "moby/buildkit"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/cert-manager/helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+cert-manager\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+jetstack\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "cert-manager",
+      "registryUrlTemplate": "https://charts.jetstack.io"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/dns/duckdns-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+duckdns\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+mmontes\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "duckdns",
+      "registryUrlTemplate": "https://mmontes11.github.io/charts"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/dns/pihole-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+pihole\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+pihole\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "pihole",
+      "registryUrlTemplate": "https://mojo2600.github.io/pihole-kubernetes"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/external-snapshotter/external-snapshotter-deployment\\.yaml$/"
+      ],
+      "matchStrings": [
+        "image:\\s+registry\\.k8s\\.io/sig-storage/snapshot-controller:(?<currentValue>.+)"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "registry.k8s.io/sig-storage/snapshot-controller",
+      "registryUrlTemplate": "https://registry.k8s.io"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/kubelet-csr-approver/kubelet-csr-approver-ocirepository\\.yaml$/"
+      ],
+      "matchStrings": [
+        "ref:\\s*\\n\\s+tag:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "ghcr.io/charts/kubelet-csr-approver",
+      "registryUrlTemplate": "https://ghcr.io"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/mariadb-operator/mariadb-operator-crds-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+mariadb-operator-crds\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+mariadb-operator\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "mariadb-operator-crds",
+      "registryUrlTemplate": "https://helm.mariadb.com/mariadb-operator"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/mariadb-operator/mariadb-operator-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+mariadb-operator\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+mariadb-operator\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "mariadb-operator",
+      "registryUrlTemplate": "https://helm.mariadb.com/mariadb-operator"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/metrics-server/helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+metrics-server\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+metrics-server\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "metrics-server",
+      "registryUrlTemplate": "https://kubernetes-sigs.github.io/metrics-server"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/metallb/metallb-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+metallb\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+metallb\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "metallb",
+      "registryUrlTemplate": "https://metallb.github.io/metallb"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/minio-operator/minio-operator-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+operator\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+minio-operator\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "operator",
+      "registryUrlTemplate": "https://operator.min.io"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/minio-operator/minio-tenant/minio-tenant-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+tenant\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+minio-operator\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "tenant",
+      "registryUrlTemplate": "https://operator.min.io"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/nvidia-dcgm-exporter/nvidia-dcgm-exporter-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+dcgm-exporter\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+nvidia-dcgm-exporter\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "dcgm-exporter",
+      "registryUrlTemplate": "https://nvidia.github.io/dcgm-exporter/helm-charts"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/nvidia-device-plugin/nvidia-device-plugin-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+nvidia-device-plugin\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+nvidia-device-plugin\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "nvidia-device-plugin",
+      "registryUrlTemplate": "https://nvidia.github.io/k8s-device-plugin"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/prometheus/blackbox-exporter-ocirepository\\.yaml$/"
+      ],
+      "matchStrings": [
+        "ref:\\s*\\n\\s+tag:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter",
+      "registryUrlTemplate": "https://ghcr.io"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/prometheus/kube-prometheus-stack-ocirepository\\.yaml$/"
+      ],
+      "matchStrings": [
+        "ref:\\s*\\n\\s+tag:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "ghcr.io/prometheus-community/charts/kube-prometheus-stack",
+      "registryUrlTemplate": "https://ghcr.io"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/redis-operator/redis-operator-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+redis-operator\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+redis-operator\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "redis-operator",
+      "registryUrlTemplate": "https://ot-container-kit.github.io/helm-charts/"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/redis-operator/redis/redis-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+redis\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+redis-operator\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "redis",
+      "registryUrlTemplate": "https://ot-container-kit.github.io/helm-charts/"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/rook/rook-ceph-cluster/rook-ceph-cluster-ocirepository\\.yaml$/"
+      ],
+      "matchStrings": [
+        "ref:\\s*\\n\\s+tag:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "ghcr.io/rook/rook-ceph-cluster",
+      "registryUrlTemplate": "https://ghcr.io"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/rook/rook-ceph-ocirepository\\.yaml$/"
+      ],
+      "matchStrings": [
+        "ref:\\s*\\n\\s+tag:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "ghcr.io/rook/rook-ceph",
+      "registryUrlTemplate": "https://ghcr.io"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/sealed-secrets/sealed-secrets-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+sealed-secrets\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+sealed-secrets\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "sealed-secrets",
+      "registryUrlTemplate": "https://bitnami-labs.github.io/sealed-secrets"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/snapscheduler/snapscheduler-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+snapscheduler\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+snapscheduler\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "snapscheduler",
+      "registryUrlTemplate": "https://backube.github.io/helm-charts/"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/synology-csi-talos/synology-csi-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+synology-csi\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+synology-csi\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "synology-csi",
+      "registryUrlTemplate": "https://zebernst.github.io/synology-csi-talos"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/synology-csi/helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+synology-csi\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+synology-csi\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "synology-csi",
+      "registryUrlTemplate": "https://christian-schlichtherle.github.io/synology-csi-chart"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/tailscale/tailscale-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+tailscale-operator\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+tailscale\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "tailscale-operator",
+      "registryUrlTemplate": "https://pkgs.tailscale.com/helmcharts"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/topolvm/topolvm-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+topolvm\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+topolvm\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "topolvm",
+      "registryUrlTemplate": "https://topolvm.github.io/topolvm"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/trust-manager/helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+trust-manager\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+jetstack\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "trust-manager",
+      "registryUrlTemplate": "https://charts.jetstack.io"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/traefik/traefik-ocirepository\\.yaml$/"
+      ],
+      "matchStrings": [
+        "ref:\\s*\\n\\s+tag:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "ghcr.io/traefik/helm/traefik",
+      "registryUrlTemplate": "https://ghcr.io"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/volsync/volsync-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+volsync\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+volsync\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "helm",
+      "packageNameTemplate": "volsync",
+      "registryUrlTemplate": "https://backube.github.io/helm-charts/"
+    }
+  ]
+}

--- a/infrastructure/kubelet-csr-approver/helmrepository.yaml
+++ b/infrastructure/kubelet-csr-approver/helmrepository.yaml
@@ -1,7 +1,0 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
-kind: HelmRepository
-metadata:
-  name: kubelet-csr-approver
-spec:
-  interval: 5m
-  url: https://postfinance.github.io/kubelet-csr-approver

--- a/infrastructure/kubelet-csr-approver/kubelet-csr-approver-helmrelease.yaml
+++ b/infrastructure/kubelet-csr-approver/kubelet-csr-approver-helmrelease.yaml
@@ -1,15 +1,11 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kubelet-csr-approver
 spec:
-  chart:
-    spec:
-      chart: kubelet-csr-approver
-      sourceRef:
-        kind: HelmRepository
-        name: kubelet-csr-approver
-      version: "1.2.2"
+  chartRef:
+    kind: OCIRepository
+    name: kubelet-csr-approver
   interval: 1h0m0s
   values:
     leaderElection: true

--- a/infrastructure/kubelet-csr-approver/kubelet-csr-approver-ocirepository.yaml
+++ b/infrastructure/kubelet-csr-approver/kubelet-csr-approver-ocirepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: kubelet-csr-approver
+spec:
+  interval: 5m
+  url: oci://ghcr.io/charts/kubelet-csr-approver
+  ref:
+    tag: "1.2.2"

--- a/infrastructure/kubelet-csr-approver/kustomization.yaml
+++ b/infrastructure/kubelet-csr-approver/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: pki
 resources:
-  - helmrepository.yaml
-  - helmrelease.yaml
+  - kubelet-csr-approver-helmrelease.yaml
+  - kubelet-csr-approver-ocirepository.yaml

--- a/infrastructure/prometheus/blackbox-exporter-helmrelease.yaml
+++ b/infrastructure/prometheus/blackbox-exporter-helmrelease.yaml
@@ -1,16 +1,12 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: blackbox-exporter
 spec:
   releaseName: blackbox-exporter
-  chart:
-    spec:
-      chart: prometheus-blackbox-exporter
-      sourceRef:
-        kind: HelmRepository
-        name: prometheus
-      version: "9.3.0"
+  chartRef:
+    kind: OCIRepository
+    name: prometheus-blackbox-exporter
   interval: 1h0m0s
   values:
     fullnameOverride: blackbox-exporter

--- a/infrastructure/prometheus/blackbox-exporter-ocirepository.yaml
+++ b/infrastructure/prometheus/blackbox-exporter-ocirepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: prometheus-blackbox-exporter
+spec:
+  interval: 5m
+  url: oci://ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter
+  ref:
+    tag: "9.3.0"

--- a/infrastructure/prometheus/kube-prometheus-stack-helmrelease.yaml
+++ b/infrastructure/prometheus/kube-prometheus-stack-helmrelease.yaml
@@ -1,15 +1,11 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack
 spec:
-  chart:
-    spec:
-      chart: kube-prometheus-stack
-      sourceRef:
-        kind: HelmRepository
-        name: prometheus
-      version: "76.4.0"
+  chartRef:
+    kind: OCIRepository
+    name: kube-prometheus-stack
   interval: 1h0m0s
   values:
     crds:

--- a/infrastructure/prometheus/kube-prometheus-stack-ocirepository.yaml
+++ b/infrastructure/prometheus/kube-prometheus-stack-ocirepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: kube-prometheus-stack
+spec:
+  interval: 5m
+  url: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack
+  ref:
+    tag: "76.4.0"

--- a/infrastructure/prometheus/kustomization.yaml
+++ b/infrastructure/prometheus/kustomization.yaml
@@ -4,8 +4,10 @@ namespace: monitoring
 resources:
   - alertmanager-httproute.yaml
   - blackbox-exporter-helmrelease.yaml
+  - blackbox-exporter-ocirepository.yaml
   - grafana-httproute.yaml
   - grafana-sealedsecret.yaml
   - kube-prometheus-stack-helmrelease.yaml
+  - kube-prometheus-stack-ocirepository.yaml
   - prometheus-helmrepository.yaml
   - prometheus-httproute.yaml

--- a/infrastructure/rook/kustomization.yaml
+++ b/infrastructure/rook/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: storage
 resources:
+  - rook-ceph-ocirepository.yaml
   - rook-helmrelease.yaml
-  - rook-helmrepository.yaml

--- a/infrastructure/rook/rook-ceph-cluster/kustomization.yaml
+++ b/infrastructure/rook/rook-ceph-cluster/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: storage
 resources:
   - ceph-httproute.yaml
+  - rook-ceph-cluster-ocirepository.yaml
   - rook-ceph-cluster-helmrelease.yaml
   - rook-ceph-dashboard-password-sealedsecret.yaml

--- a/infrastructure/rook/rook-ceph-cluster/rook-ceph-cluster-helmrelease.yaml
+++ b/infrastructure/rook/rook-ceph-cluster/rook-ceph-cluster-helmrelease.yaml
@@ -1,16 +1,12 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: rook-ceph-cluster
 spec:
   releaseName: rook-ceph-cluster
-  chart:
-    spec:
-      chart: rook-ceph-cluster
-      sourceRef:
-        kind: HelmRepository
-        name: rook
-      version: "v1.18.2"
+  chartRef:
+    kind: OCIRepository
+    name: rook-ceph-cluster
   interval: 1h0m0s
   values:
     operatorNamespace: storage

--- a/infrastructure/rook/rook-ceph-cluster/rook-ceph-cluster-ocirepository.yaml
+++ b/infrastructure/rook/rook-ceph-cluster/rook-ceph-cluster-ocirepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rook-ceph-cluster
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "v1.18.2"
+  url: oci://ghcr.io/rook/rook-ceph-cluster

--- a/infrastructure/rook/rook-ceph-ocirepository.yaml
+++ b/infrastructure/rook/rook-ceph-ocirepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rook-ceph
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "v1.18.2"
+  url: oci://ghcr.io/rook/rook-ceph

--- a/infrastructure/rook/rook-helmrelease.yaml
+++ b/infrastructure/rook/rook-helmrelease.yaml
@@ -1,16 +1,12 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: rook
 spec:
   releaseName: rook
-  chart:
-    spec:
-      chart: rook-ceph
-      sourceRef:
-        kind: HelmRepository
-        name: rook
-      version: "v1.18.2"
+  chartRef:
+    kind: OCIRepository
+    name: rook-ceph
   interval: 1h0m0s
   values:
     crds:

--- a/infrastructure/traefik/external-helmrelease.yaml
+++ b/infrastructure/traefik/external-helmrelease.yaml
@@ -1,15 +1,11 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: traefik-external
 spec:
-  chart:
-    spec:
-      chart: traefik
-      sourceRef:
-        kind: HelmRepository
-        name: traefik
-      version: "32.1.0"
+  chartRef:
+    kind: OCIRepository
+    name: traefik
   interval: 1h0m0s
   values:
     instanceLabelOverride: traefik-external

--- a/infrastructure/traefik/internal-helmrelease.yaml
+++ b/infrastructure/traefik/internal-helmrelease.yaml
@@ -1,15 +1,11 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: traefik-internal
 spec:
-  chart:
-    spec:
-      chart: traefik
-      sourceRef:
-        kind: HelmRepository
-        name: traefik
-      version: "32.1.0"
+  chartRef:
+    kind: OCIRepository
+    name: traefik
   interval: 1h0m0s
   values:
     instanceLabelOverride: traefik-internal

--- a/infrastructure/traefik/kustomization.yaml
+++ b/infrastructure/traefik/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - external-clusterrolebinding.yaml
   - external-gateway.yaml
   - external-helmrelease.yaml
-  - helmrepository.yaml
   - internal-clusterrolebinding.yaml
   - internal-gateway.yaml
   - internal-helmrelease.yaml
+  - traefik-ocirepository.yaml

--- a/infrastructure/traefik/traefik-ocirepository.yaml
+++ b/infrastructure/traefik/traefik-ocirepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: traefik
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "32.1.0"
+  url: oci://ghcr.io/traefik/helm/traefik


### PR DESCRIPTION
## Summary

Migrate infrastructure Helm charts from HTTP repositories to OCI registries and add Renovate automation for automatic version bumps.

## Charts Migrated to OCI

| Chart | Old Source | New OCI Source |
|-------|-----------|----------------|
| kube-prometheus-stack | prometheus-community.github.io/helm-charts | ghcr.io/prometheus-community/charts/kube-prometheus-stack |
| prometheus-blackbox-exporter | prometheus-community.github.io/helm-charts | ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter |
| kubelet-csr-approver | postfinance.github.io/kubelet-csr-approver | ghcr.io/charts/kubelet-csr-approver |
| rook-ceph | charts.rook.io/release | ghcr.io/rook/rook-ceph |
| rook-ceph-cluster | charts.rook.io/release | ghcr.io/rook/rook-ceph-cluster |
| traefik | helm.traefik.io/traefik | ghcr.io/traefik/helm/traefik |

## Changes

### Infrastructure Migrations
- Created `*-ocirepository.yaml` files with `layerSelector` for Helm chart content extraction
- Updated HelmReleases to use `chartRef` pointing to OCIRepository (apiVersion helm.toolkit.fluxcd.io/v2)
- Updated kustomization.yaml files to reference OCIRepository instead of HelmRepository
- Removed obsolete HelmRepository files

### Renovate Configuration
- Added `renovate.json` with custom managers for all infrastructure workloads
- Configured Docker datasource for OCI chart tracking (matching `ref.tag` pattern)
- Configured Helm datasource for remaining HTTP-based charts
- Set `prConcurrentLimit: 0` to disable auto-merge
- Removed workloads not deployed in cluster (kubernetes-dashboard, csi-driver-nfs)

## Testing
- Verified all OCI charts can be pulled with `helm pull oci://...`
- Confirmed chart contents (Chart.yaml, values.yaml, templates/) are valid Helm charts
- All OCIRepository files follow naming convention: `<resource-name>-ocirepository.yaml`