### PR TITLE
migrate mariadb-operator to 26.6.0 using OCI registries

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,26 +77,26 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/(^|/)infrastructure/mariadb-operator/mariadb-operator-crds-helmrelease\\.yaml$/"
+        "/(^|/)infrastructure/mariadb-operator/mariadb-operator-crds-ocirepository\\.yaml$/"
       ],
       "matchStrings": [
-        "chart:\\s+mariadb-operator-crds\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+mariadb-operator\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+        "ref:\\s*\\n\\s+tag:\\s+\"?(?<currentValue>[^\"]+)\"?"
       ],
-      "datasourceTemplate": "helm",
-      "packageNameTemplate": "mariadb-operator-crds",
-      "registryUrlTemplate": "https://helm.mariadb.com/mariadb-operator"
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "ghcr.io/mariadb-operator/charts/mariadb-operator-crds",
+      "registryUrlTemplate": "https://ghcr.io"
     },
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/(^|/)infrastructure/mariadb-operator/mariadb-operator-helmrelease\\.yaml$/"
+        "/(^|/)infrastructure/mariadb-operator/mariadb-operator-ocirepository\\.yaml$/"
       ],
       "matchStrings": [
-        "chart:\\s+mariadb-operator\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+mariadb-operator\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+        "ref:\\s*\\n\\s+tag:\\s+\"?(?<currentValue>[^\"]+)\"?"
       ],
-      "datasourceTemplate": "helm",
-      "packageNameTemplate": "mariadb-operator",
-      "registryUrlTemplate": "https://helm.mariadb.com/mariadb-operator"
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "ghcr.io/mariadb-operator/charts/mariadb-operator",
+      "registryUrlTemplate": "https://ghcr.io"
     },
     {
       "customType": "regex",

--- a/infrastructure/mariadb-operator/kustomization.yaml
+++ b/infrastructure/mariadb-operator/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: database
 resources:
   - mariadb-operator-crds-helmrelease.yaml
+  - mariadb-operator-crds-ocirepository.yaml
   - mariadb-operator-helmrelease.yaml
-  - mariadb-operator-helmrepository.yaml
+  - mariadb-operator-ocirepository.yaml

--- a/infrastructure/mariadb-operator/mariadb-operator-crds-helmrelease.yaml
+++ b/infrastructure/mariadb-operator/mariadb-operator-crds-helmrelease.yaml
@@ -3,11 +3,7 @@ kind: HelmRelease
 metadata:
   name: mariadb-operator-crds
 spec:
-  chart:
-    spec:
-      chart: mariadb-operator-crds
-      sourceRef:
-        kind: HelmRepository
-        name: mariadb-operator
-      version: "26.3.0"
+  chartRef:
+    kind: OCIRepository
+    name: mariadb-operator-crds
   interval: 1h0m0s

--- a/infrastructure/mariadb-operator/mariadb-operator-crds-ocirepository.yaml
+++ b/infrastructure/mariadb-operator/mariadb-operator-crds-ocirepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mariadb-operator-crds
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "26.6.0"
+  url: oci://ghcr.io/mariadb-operator/charts/mariadb-operator-crds

--- a/infrastructure/mariadb-operator/mariadb-operator-helmrelease.yaml
+++ b/infrastructure/mariadb-operator/mariadb-operator-helmrelease.yaml
@@ -5,13 +5,9 @@ metadata:
 spec:
   dependsOn:
     - name: mariadb-operator-crds
-  chart:
-    spec:
-      chart: mariadb-operator
-      sourceRef:
-        kind: HelmRepository
-        name: mariadb-operator
-      version: "26.3.0"
+  chartRef:
+    kind: OCIRepository
+    name: mariadb-operator
   interval: 1h0m0s
   values:
     logLevel: INFO

--- a/infrastructure/mariadb-operator/mariadb-operator-helmrepository.yaml
+++ b/infrastructure/mariadb-operator/mariadb-operator-helmrepository.yaml
@@ -1,7 +1,0 @@
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: mariadb-operator
-spec:
-  interval: 5m
-  url: https://helm.mariadb.com/mariadb-operator

--- a/infrastructure/mariadb-operator/mariadb-operator-ocirepository.yaml
+++ b/infrastructure/mariadb-operator/mariadb-operator-ocirepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mariadb-operator
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "26.6.0"
+  url: oci://ghcr.io/mariadb-operator/charts/mariadb-operator


### PR DESCRIPTION
## Changes

- Migrate mariadb-operator from HelmRepository to OCIRepository for both `mariadb-operator` and `mariadb-operator-crds` charts
- Upgrade version from 26.3.0 to 26.6.0
- Update renovate.json rules to track OCI images from ghcr.io instead of the deprecated helm.mariadb.com repository

## Charts

- `oci://ghcr.io/mariadb-operator/charts/mariadb-operator-crds` version `26.6.0`
- `oci://ghcr.io/mariadb-operator/charts/mariadb-operator` version `26.6.0`

## References

- [RELEASE_26.6.0](https://github.com/mariadb-operator/mariadb-operator/releases/tag/26.6.0)
- [Upgrade Guide](https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_26.6.0.md)