### PR TITLE
feat: add seaweedfs-operator deployment manifests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -396,6 +396,18 @@
       "datasourceTemplate": "helm",
       "packageNameTemplate": "headlamp",
       "registryUrlTemplate": "https://kubernetes-sigs.github.io/headlamp/"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/seaweedfs-operator/seaweedfs-operator-helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "chart:\\s+seaweedfs-operator\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+seaweedfs-operator\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "seaweedfs/seaweedfs-operator",
+      "extractVersion": "^(?<version>\\d+\\.\\d+\\.\\d+)$"
     }
   ]
 }

--- a/clusters/homelab/storage.yaml
+++ b/clusters/homelab/storage.yaml
@@ -218,3 +218,17 @@ spec:
   path: ./infrastructure/minio-operator/minio-tenant
   prune: true
   timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: seaweedfs-operator
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infrastructure/seaweedfs-operator
+  prune: true
+  timeout: 5m

--- a/infrastructure/seaweedfs-operator/kustomization.yaml
+++ b/infrastructure/seaweedfs-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: storage
+resources:
+  - seaweedfs-operator-helmrepository.yaml
+  - seaweedfs-operator-helmrelease.yaml

--- a/infrastructure/seaweedfs-operator/seaweedfs-operator-helmrelease.yaml
+++ b/infrastructure/seaweedfs-operator/seaweedfs-operator-helmrelease.yaml
@@ -1,0 +1,32 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: seaweedfs-operator
+spec:
+  chart:
+    spec:
+      chart: seaweedfs-operator
+      sourceRef:
+        kind: HelmRepository
+        name: seaweedfs-operator
+      version: "0.1.32"
+  interval: 1h0m0s
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 120Mi
+      limits:
+        cpu: 500m
+        memory: 500Mi
+    grafanaDashboard:
+      enabled: true
+    serviceMonitor:
+      enabled: true
+      interval: 1m
+      scrapeTimeout: 10s
+      honorLabels: true

--- a/infrastructure/seaweedfs-operator/seaweedfs-operator-helmrelease.yaml
+++ b/infrastructure/seaweedfs-operator/seaweedfs-operator-helmrelease.yaml
@@ -16,6 +16,8 @@ spec:
   upgrade:
     crds: CreateReplace
   values:
+    crds:
+      create: true
     resources:
       requests:
         cpu: 200m
@@ -27,6 +29,5 @@ spec:
       enabled: true
     serviceMonitor:
       enabled: true
-      interval: 1m
-      scrapeTimeout: 10s
-      honorLabels: true
+    webhook:
+      enabled: true

--- a/infrastructure/seaweedfs-operator/seaweedfs-operator-helmrepository.yaml
+++ b/infrastructure/seaweedfs-operator/seaweedfs-operator-helmrepository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: seaweedfs-operator
+spec:
+  interval: 5m
+  url: https://seaweedfs.github.io/seaweedfs-operator/


### PR DESCRIPTION
## Summary

Add Flux CD deployment manifests for the seaweedfs-operator as a replacement for the archived minio-operator.

## Changes

- `infrastructure/seaweedfs-operator/kustomization.yaml` — Kustomization in `storage` namespace
- `infrastructure/seaweedfs-operator/seaweedfs-operator-helmrepository.yaml` — HelmRepository pointing to `https://seaweedfs.github.io/seaweedfs-operator/`
- `infrastructure/seaweedfs-operator/seaweedfs-operator-helmrelease.yaml` — HelmRelease for chart v0.1.32 with:
  - Resource requests/limits (200m/120Mi → 500m/500Mi)
  - Grafana dashboard enabled
  - ServiceMonitor enabled (1m interval)

## Next Steps

- [ ] Create `Seaweed` CR with S3, IAM, pre-provisioned storage (2Ti Synology PV)
- [ ] Create HTTPRoutes for S3 and filer external access
- [ ] Create TLS certificates via cert-manager
- [ ] Migrate buckets (`pvc`, `database`, `management`)
- [ ] Update ScrapeConfig for metrics
- [ ] Remove `infrastructure/minio-operator/`