### PR TITLE
chore: decommission minio

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -122,30 +122,7 @@
       "packageNameTemplate": "metallb",
       "registryUrlTemplate": "https://metallb.github.io/metallb"
     },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)infrastructure/minio-operator/minio-operator-helmrelease\\.yaml$/"
-      ],
-      "matchStrings": [
-        "chart:\\s+operator\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+minio-operator\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
-      ],
-      "datasourceTemplate": "helm",
-      "packageNameTemplate": "operator",
-      "registryUrlTemplate": "https://operator.min.io"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)infrastructure/minio-operator/minio-tenant/minio-tenant-helmrelease\\.yaml$/"
-      ],
-      "matchStrings": [
-        "chart:\\s+tenant\\s*\\n\\s+sourceRef:\\s*\\n\\s+kind:\\s+HelmRepository\\s*\\n\\s+name:\\s+minio-operator\\s*\\n\\s+version:\\s+\"?(?<currentValue>[^\"]+)\"?"
-      ],
-      "datasourceTemplate": "helm",
-      "packageNameTemplate": "tenant",
-      "registryUrlTemplate": "https://operator.min.io"
-    },
+ 
     {
       "customType": "regex",
       "managerFilePatterns": [

--- a/clusters/homelab/pki.yaml
+++ b/clusters/homelab/pki.yaml
@@ -123,20 +123,3 @@ spec:
   path: ./infrastructure/trust-manager/homelab-bundle
   prune: true
   timeout: 5m
----
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: trust-manager-minio-bundle
-  namespace: flux-system
-spec:
-  dependsOn:
-    - name: trust-manager
-    - name: cert-manager-homelab-issuer
-  interval: 5m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-  path: ./infrastructure/trust-manager/minio-bundle
-  prune: true
-  timeout: 5m

--- a/clusters/homelab/storage.yaml
+++ b/clusters/homelab/storage.yaml
@@ -190,38 +190,6 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: minio-operator
-  namespace: flux-system
-spec:
-  interval: 5m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-  path: ./infrastructure/minio-operator
-  prune: true
-  timeout: 5m
----
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: minio-tenant
-  namespace: flux-system
-spec:
-  dependsOn:
-    - name: minio-operator
-    - name: cert-manager-crds
-    - name: prometheus-crds
-  interval: 5m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-  path: ./infrastructure/minio-operator/minio-tenant
-  prune: true
-  timeout: 5m
----
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
   name: seaweedfs-operator
   namespace: flux-system
 spec:


### PR DESCRIPTION
## Summary

Removes all MinIO references outside of `infrastructure/minio-operator/` to fully decommission the service.

## Changes

- **`clusters/homelab/storage.yaml`** — Removed `minio-operator` and `minio-tenant` Flux Kustomizations
- **`clusters/homelab/pki.yaml`** — Removed `trust-manager-minio-bundle` Flux Kustomization
- **`infrastructure/prometheus/kube-prometheus-stack-helmrelease.yaml`** — Removed MinIO Grafana dashboard (gnetId: 13502)
- **`infrastructure/trust-manager/minio-bundle/`** — Deleted entire directory (CA trust bundle for MinIO)
- **`.github/renovate.json`** — Removed 2 Renovate custom managers for MinIO operator and tenant Helm charts

## Notes

- `infrastructure/minio-operator/` directory is **retained** in the repo but no longer deployed via Flux
- SeaweedFS comments referencing `minio-console` are purely documentary and left as-is
- No MinIO references exist in `k8s-ai` or `k8s-media` repos