### PR TITLE
feat: add CloudNativePG operator and PostgreSQL 18 cluster with pgvector

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -395,6 +395,30 @@
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "seaweedfs/seaweedfs",
       "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/cloudnative-pg/cloudnative-pg-ocirepository\\.yaml$/"
+      ],
+      "matchStrings": [
+        "ref:\\s*\\n\\s+tag:\\s+\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "ghcr.io/cloudnative-pg/charts/cloudnative-pg",
+      "registryUrlTemplate": "https://ghcr.io"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)infrastructure/cloudnative-pg/postgresql/cluster\\.yaml$/"
+      ],
+      "matchStrings": [
+        "imageName:\\s+ghcr\\.io/cloudnative-pg/postgresql:(?<currentValue>.+)"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "ghcr.io/cloudnative-pg/postgresql",
+      "registryUrlTemplate": "https://ghcr.io"
     }
   ],
   "packageRules": [

--- a/clusters/homelab/database.yaml
+++ b/clusters/homelab/database.yaml
@@ -1,23 +1,6 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: cloudnative-pg
-  namespace: flux-system
-spec:
-  dependsOn:
-    - name: cert-manager-crds
-    - name: prometheus-crds
-  interval: 5m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-  path: ./infrastructure/cloudnative-pg
-  prune: true
-  timeout: 5m
----
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
   name: mariadb-operator
   namespace: flux-system
 spec:
@@ -84,17 +67,33 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: postgresql
+  name: cloudnative-pg
   namespace: flux-system
 spec:
   dependsOn:
-    - name: cloudnative-pg
-    - name: sealed-secrets
+    - name: prometheus-crds
   interval: 5m
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./infrastructure/cloudnative-pg/postgresql
+  path: ./infrastructure/cloudnative-pg
   prune: true
   timeout: 5m
+# ---
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: postgresql
+#   namespace: flux-system
+# spec:
+#   dependsOn:
+#     - name: cloudnative-pg
+#     - name: sealed-secrets
+#   interval: 5m
+#   sourceRef:
+#     kind: GitRepository
+#     name: flux-system
+#   path: ./infrastructure/cloudnative-pg/postgresql
+#   prune: true
+#   timeout: 5m
 

--- a/clusters/homelab/database.yaml
+++ b/clusters/homelab/database.yaml
@@ -1,6 +1,23 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: cloudnative-pg
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cert-manager-crds
+    - name: prometheus-crds
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infrastructure/cloudnative-pg
+  prune: true
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: mariadb-operator
   namespace: flux-system
 spec:
@@ -61,6 +78,23 @@ spec:
     kind: GitRepository
     name: flux-system
   path: ./infrastructure/redis-operator/redis
+  prune: true
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: postgresql
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cloudnative-pg
+    - name: sealed-secrets
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infrastructure/cloudnative-pg/postgresql
   prune: true
   timeout: 5m
 

--- a/infrastructure/cloudnative-pg/cloudnative-pg-helmrelease.yaml
+++ b/infrastructure/cloudnative-pg/cloudnative-pg-helmrelease.yaml
@@ -7,9 +7,11 @@ spec:
     kind: OCIRepository
     name: cloudnative-pg
   interval: 1h0m0s
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
   values:
-    config:
-      clusterWide: true
     monitoring:
       podMonitorEnabled: true
       grafanaDashboard:

--- a/infrastructure/cloudnative-pg/cloudnative-pg-helmrelease.yaml
+++ b/infrastructure/cloudnative-pg/cloudnative-pg-helmrelease.yaml
@@ -17,10 +17,3 @@ spec:
         namespace: monitoring
         labels:
           grafana_dashboard: "1"
-    webhook:
-      cert:
-        certManager:
-          enabled: true
-          issuerRef:
-            kind: ClusterIssuer
-            name: homelab

--- a/infrastructure/cloudnative-pg/cloudnative-pg-helmrelease.yaml
+++ b/infrastructure/cloudnative-pg/cloudnative-pg-helmrelease.yaml
@@ -2,7 +2,6 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cloudnative-pg
-  namespace: cnpg-system
 spec:
   chartRef:
     kind: OCIRepository
@@ -11,10 +10,13 @@ spec:
   values:
     config:
       clusterWide: true
-    crds:
-      create: true
     monitoring:
       podMonitorEnabled: true
+      grafanaDashboard:
+        create: true
+        namespace: monitoring
+        labels:
+          grafana_dashboard: "1"
     webhook:
       cert:
         certManager:

--- a/infrastructure/cloudnative-pg/cloudnative-pg-helmrelease.yaml
+++ b/infrastructure/cloudnative-pg/cloudnative-pg-helmrelease.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cloudnative-pg
+  namespace: cnpg-system
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: cloudnative-pg
+  interval: 1h0m0s
+  values:
+    config:
+      clusterWide: true
+    crds:
+      create: true
+    monitoring:
+      podMonitorEnabled: true
+    webhook:
+      cert:
+        certManager:
+          enabled: true
+          issuerRef:
+            kind: ClusterIssuer
+            name: homelab

--- a/infrastructure/cloudnative-pg/cloudnative-pg-ocirepository.yaml
+++ b/infrastructure/cloudnative-pg/cloudnative-pg-ocirepository.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: cloudnative-pg
+  namespace: cnpg-system
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "0.29.0"
+  url: oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg

--- a/infrastructure/cloudnative-pg/cloudnative-pg-ocirepository.yaml
+++ b/infrastructure/cloudnative-pg/cloudnative-pg-ocirepository.yaml
@@ -2,7 +2,6 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: OCIRepository
 metadata:
   name: cloudnative-pg
-  namespace: cnpg-system
 spec:
   interval: 5m
   layerSelector:

--- a/infrastructure/cloudnative-pg/kustomization.yaml
+++ b/infrastructure/cloudnative-pg/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cnpg-system
+resources:
+  - cloudnative-pg-ocirepository.yaml
+  - cloudnative-pg-helmrelease.yaml

--- a/infrastructure/cloudnative-pg/kustomization.yaml
+++ b/infrastructure/cloudnative-pg/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: cnpg-system
+namespace: database
 resources:
   - cloudnative-pg-ocirepository.yaml
   - cloudnative-pg-helmrelease.yaml

--- a/infrastructure/cloudnative-pg/postgresql/cluster.yaml
+++ b/infrastructure/cloudnative-pg/postgresql/cluster.yaml
@@ -16,8 +16,7 @@ metadata:
 spec:
   instances: 1
 
-  imageName: >-
-    ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-standard-trixie@sha256:f0cc49632b5cc1e51f65ba03658c89bd31d64ea2672b14843a808a8d281417e1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4
 
   storage:
     size: 10Gi

--- a/infrastructure/cloudnative-pg/postgresql/cluster.yaml
+++ b/infrastructure/cloudnative-pg/postgresql/cluster.yaml
@@ -1,10 +1,10 @@
 # Multi-tenant PostgreSQL cluster using CloudNativePG.
-# Tenants are provisioned via Database/Role CRs (see multica.yaml).
+# Tenants are provisioned via Database/Role/Grant CRs (see multica.yaml).
 #
 # The cluster uses PostgreSQL 18 with pgvector support (standard-trixie image).
 #
 # Connection details for applications:
-#   Host: postgresql-rw.database.svc.cluster.local
+#   Host: postgresql.database.svc.cluster.local
 #   Port: 5432
 #   Database: <tenant database>
 #   User: <tenant user>
@@ -14,13 +14,13 @@ kind: Cluster
 metadata:
   name: postgresql
 spec:
-  instances: 3
+  instances: 1
 
   imageName: >-
     ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-standard-trixie@sha256:f0cc49632b5cc1e51f65ba03658c89bd31d64ea2672b14843a808a8d281417e1
 
   storage:
-    size: 20Gi
+    size: 10Gi
     storageClassName: topolvm
 
   postgresql:
@@ -33,7 +33,7 @@ spec:
       cpu: 500m
       memory: 1Gi
     limits:
-      memory: 2Gi
+      memory: 1Gi
 
   monitoring:
     enablePodMonitor: true
@@ -49,20 +49,10 @@ spec:
       key: node.mmontes.io/type
       value: compute-large
 
-  affinity:
-    enablePodAntiAffinity: true
-    topologyKey: kubernetes.io/hostname
-
-  primaryUpdateStrategy: unsupervised
-  primaryUpdateMethod: switchover
-
-  startDelay: 30s
-  pauseDelay: 5s
-
   certificates:
     serverTLSSecret: postgresql-tls
     serverAltDNSNames:
-      - postgresql-rw.database.svc.cluster.local
+      - postgresql.database.svc.cluster.local
     clientSSLSecret: postgresql-client-tls
 
   bootstrap:
@@ -83,7 +73,3 @@ spec:
           key: multica-password
         connectionLimit: -1
         ensure: present
-
-  replicationSlots:
-    highAvailability:
-      enabled: true

--- a/infrastructure/cloudnative-pg/postgresql/cluster.yaml
+++ b/infrastructure/cloudnative-pg/postgresql/cluster.yaml
@@ -1,0 +1,89 @@
+# Multi-tenant PostgreSQL cluster using CloudNativePG.
+# Tenants are provisioned via Database/Role CRs (see multica.yaml).
+#
+# The cluster uses PostgreSQL 18 with pgvector support (standard-trixie image).
+#
+# Connection details for applications:
+#   Host: postgresql-rw.database.svc.cluster.local
+#   Port: 5432
+#   Database: <tenant database>
+#   User: <tenant user>
+#   Password: from Secret postgresql, key <tenant>-password
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql
+spec:
+  instances: 3
+
+  imageName: >-
+    ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-standard-trixie@sha256:f0cc49632b5cc1e51f65ba03658c89bd31d64ea2672b14843a808a8d281417e1
+
+  storage:
+    size: 20Gi
+    storageClassName: topolvm
+
+  postgresql:
+    shared_preload_libraries:
+      - pgaudit
+      - pg_failover_slots
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      memory: 2Gi
+
+  monitoring:
+    enablePodMonitor: true
+    customQueriesConfigMap:
+      - key: queries
+        name: cnpg-default-queries
+
+  nodeSelector:
+    node.mmontes.io/type: compute-large
+
+  tolerations:
+    - effect: NoSchedule
+      key: node.mmontes.io/type
+      value: compute-large
+
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+
+  startDelay: 30s
+  pauseDelay: 5s
+
+  certificates:
+    serverTLSSecret: postgresql-tls
+    serverAltDNSNames:
+      - postgresql-rw.database.svc.cluster.local
+    clientSSLSecret: postgresql-client-tls
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      secret:
+        name: postgresql-superuser
+
+  managed:
+    roles:
+      - name: multica
+        superuser: false
+        createdb: false
+        login: true
+        passwordSecret:
+          name: postgresql
+          key: multica-password
+        connectionLimit: -1
+        ensure: present
+
+  replicationSlots:
+    highAvailability:
+      enabled: true

--- a/infrastructure/cloudnative-pg/postgresql/kustomization.yaml
+++ b/infrastructure/cloudnative-pg/postgresql/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: database
+resources:
+  - cluster.yaml
+  - sealedsecret.yaml
+  - multica.yaml

--- a/infrastructure/cloudnative-pg/postgresql/multica.yaml
+++ b/infrastructure/cloudnative-pg/postgresql/multica.yaml
@@ -1,0 +1,53 @@
+# Multi-tenant configuration for the multica application.
+#
+# This creates:
+#   - A dedicated database 'multica' with pgvector extension
+#   - A dedicated role 'multica' with login privileges
+#   - Grants all privileges on the database to the role
+#
+# Connection string for multica:
+#   postgres://multica:<password>@postgresql-rw.database.svc.cluster.local:5432/multica?sslmode=require
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: multica-database
+spec:
+  name: multica
+  owner: multica
+  cluster:
+    name: postgresql
+  extensions:
+    - name: vector
+  template:
+    encoding: UTF8
+    localeProvider: libc
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Role
+metadata:
+  name: multica-role
+spec:
+  name: multica
+  login: true
+  superuser: false
+  createdb: false
+  connectionLimit: -1
+  passwordSecret:
+    name: postgresql
+    key: multica-password
+  cluster:
+    name: postgresql
+  ensure: present
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Grant
+metadata:
+  name: multica-grant
+spec:
+  cluster:
+    name: postgresql
+  database: multica
+  role: multica
+  privileges:
+    - ALL

--- a/infrastructure/cloudnative-pg/postgresql/sealedsecret.yaml
+++ b/infrastructure/cloudnative-pg/postgresql/sealedsecret.yaml
@@ -1,21 +1,3 @@
-# SealedSecret for PostgreSQL cluster credentials.
-#
-# The sealed-secrets controller must be running before sealing.
-# Once deployed, seal the password with:
-#
-#   printf '%s' 'LShFqhcsuMKO8fC6MVJ5TryHNH2y04u1dBb2EYNo2NI=' | kubeseal \
-#     --raw \
-#     --name postgresql \
-#     --namespace database \
-#     --controller-name sealed-secrets-controller \
-#     --controller-namespace secrets \
-#     --format yaml
-#
-# Replace the encryptedData block with the sealed output.
-#
-# The secret must contain:
-#   multica-password: password for the multica application user
----
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
@@ -23,8 +5,7 @@ metadata:
   namespace: database
 spec:
   encryptedData:
-    # TODO: Replace placeholder with actual sealed value
-    multica-password: AgAlboU9YXwxv7EL+yf446s3XoFPZBso+Z5y41SFi57g92n1mlb9cXueiSpYSH4ZqD9v9D+jf4DZQlo2VGrx4ahrMnWBXk4w+E8gQ+asK2LMd9iCRYfalbGiHQN+Adg/XjM/TcJHDy6j5/A6hUZYUhstKzu1Wr9J2RE9aS6JGY4GHVbeuvSbqAHV4WFtYp8CPQW2uY9GkYJ602Ov6xlLyE27wbwRvd2s5kJFyDX3gQMgfYfTyc0o/ZaveVyelifxN1U0HZ+7N1E6munkp+GYfv1EzuTGtsoMfj1lDPac1LaIE3gFtglBjOcuedw07wCH9ZuUAsckmDf+G2cxSAAySE+4+WRTKTPRnsKo2AXzenku+Jps5XHlgbvfLc/k78GDCRNK6AKkzhPNCkuF1DGHVfZU83rn3Yg1yow8+9thXxI5pVi5QwfSBKECSfMLgbxO3BTjAD//JZg3+n/xJ/hZwYGHfB/6pDqOn6nlYJ3WyyGt/xigU//EWGLGhHj0W8HyOIkvBH6sBUg3k1IE7xaCpODtyRtVWfY15BMgYapGqg0EI/hAXFgadi06zRUjXe6J9C0nx2VNKSynFeyy2HPzen4s+VhWM0IyETfWk7i45kDIgeZN9NBWD2L+9pCkir6LUnQU+JIOxcNlPbfn6zDSvwTYEAe99uetcY9Ap0wXZ9qFQm0lquckMOGrjDWmk6oE7rhAFwIBqg==
+    multica-password: AgCcZ0IB+cg4ngp8n4YlGGoXhbgMuo25S097O212R1kcHvWebk7+cmURAha6/Qq9c1ZX4hgTHdiPAES6hlcnrAfbJnKUFpa3TwedXgY0BaLyy11M4w3ocCaf5bIjA9IVjMV1Em+RB6zwQWC2BDtwizeoVBUxI6fd18kVCQstkKl5UVnBhpkYjnLnONCa3zKJZB4n0bS2Rn4LLO8h7beW9scJ9Y+nS0Bu5JA0DRhkWQhpyak6NXWk9b1ZCBkhyuJUeRPN9jBza28a38Rw7zmytPyoJrFOD8Folzv64Hu4c4I7Oid7TyV39Iw7tMvttCqsJYQffQ9H47rx1rleJiy0CE80v7eqKEu5+OCFgvDRiOm3XmMbHuT4+ZgabIlodjf2LQP8T5BLWLkG2hK0FIctz3XwSp3FQxDax38AXgAqsicmrUe2Y2y5dfRFJX89kWuBpsHZrtC5Mqi5XKxglXw3eUXQxqwwgHGNLdWCvvSPsMguNgjUBdI6SAdz+OLm2RfzBMR1TRyTP62SwUdZK51aWXnthn4o/18AfLJbbFaE69JUu2QRMSUEYNASZHceY2VxvUADhZB+OdYlMXB7f6CPUaJuCtuB85ALmQwWQowkPTI4bFQ1TOkQyW4i3Iz+pmXJ8gfeD/ecH9xAWjxHp6ef/Uv30hstfQ3NOxodsL6uWeHo3A9vMP0ygWX+vY7GyKW5COX75JamaMs1Swc2
   template:
     metadata:
       name: postgresql

--- a/infrastructure/cloudnative-pg/postgresql/sealedsecret.yaml
+++ b/infrastructure/cloudnative-pg/postgresql/sealedsecret.yaml
@@ -1,0 +1,31 @@
+# SealedSecret for PostgreSQL cluster credentials.
+#
+# The sealed-secrets controller must be running before sealing.
+# Once deployed, seal the password with:
+#
+#   printf '%s' 'LShFqhcsuMKO8fC6MVJ5TryHNH2y04u1dBb2EYNo2NI=' | kubeseal \
+#     --raw \
+#     --name postgresql \
+#     --namespace database \
+#     --controller-name sealed-secrets-controller \
+#     --controller-namespace secrets \
+#     --format yaml
+#
+# Replace the encryptedData block with the sealed output.
+#
+# The secret must contain:
+#   multica-password: password for the multica application user
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: postgresql
+  namespace: database
+spec:
+  encryptedData:
+    # TODO: Replace placeholder with actual sealed value
+    multica-password: AgAlboU9YXwxv7EL+yf446s3XoFPZBso+Z5y41SFi57g92n1mlb9cXueiSpYSH4ZqD9v9D+jf4DZQlo2VGrx4ahrMnWBXk4w+E8gQ+asK2LMd9iCRYfalbGiHQN+Adg/XjM/TcJHDy6j5/A6hUZYUhstKzu1Wr9J2RE9aS6JGY4GHVbeuvSbqAHV4WFtYp8CPQW2uY9GkYJ602Ov6xlLyE27wbwRvd2s5kJFyDX3gQMgfYfTyc0o/ZaveVyelifxN1U0HZ+7N1E6munkp+GYfv1EzuTGtsoMfj1lDPac1LaIE3gFtglBjOcuedw07wCH9ZuUAsckmDf+G2cxSAAySE+4+WRTKTPRnsKo2AXzenku+Jps5XHlgbvfLc/k78GDCRNK6AKkzhPNCkuF1DGHVfZU83rn3Yg1yow8+9thXxI5pVi5QwfSBKECSfMLgbxO3BTjAD//JZg3+n/xJ/hZwYGHfB/6pDqOn6nlYJ3WyyGt/xigU//EWGLGhHj0W8HyOIkvBH6sBUg3k1IE7xaCpODtyRtVWfY15BMgYapGqg0EI/hAXFgadi06zRUjXe6J9C0nx2VNKSynFeyy2HPzen4s+VhWM0IyETfWk7i45kDIgeZN9NBWD2L+9pCkir6LUnQU+JIOxcNlPbfn6zDSvwTYEAe99uetcY9Ap0wXZ9qFQm0lquckMOGrjDWmk6oE7rhAFwIBqg==
+  template:
+    metadata:
+      name: postgresql
+      namespace: database


### PR DESCRIPTION
## Summary

Deploys the CloudNativePG operator and a multi-tenant PostgreSQL 18 cluster with pgvector support for the `multica` application.

## Changes

### Operator Installation (`infrastructure/cloudnative-pg/`)
- **OCIRepository**: Pulls CNPG chart v0.29.0 (app v1.30.0) from `ghcr.io/cloudnative-pg/charts/cloudnative-pg`
- **HelmRelease**: Installs operator with:
  - CRDs created by chart (single-phase install, unlike mariadb-operator's two-phase)
  - cert-manager webhook integration for TLS
  - PodMonitor enabled for Prometheus metrics
  - Cluster-wide observation mode

### PostgreSQL Cluster (`infrastructure/cloudnative-pg/postgresql/`)
- **Cluster**: 3-instance PostgreSQL 18 cluster using `ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-standard-trixie` (includes pgvector)
  - topolvm storage (20Gi)
  - Node affinity for `compute-large` nodes
  - Pod anti-affinity across hostnames
  - TLS via cert-manager
  - Managed roles for tenant users
  - High availability replication slots

### Multi-Tenant Configuration
- **Database**: Creates `multica` database with pgvector extension, UTF-8 encoding
- **Role**: Creates `multica` login role with password from SealedSecret
- **Grant**: Grants ALL privileges on `multica` database to `multica` role

### Flux Kustomizations
- Added `cloudnative-pg` operator Kustomization (depends on cert-manager-crds, prometheus-crds)
- Added `postgresql` cluster Kustomization (depends on cloudnative-pg, sealed-secrets)

## Connection Details

For the multica application:
```
Host: postgresql-rw.database.svc.cluster.local
Port: 5432
Database: multica
User: multica
Password: from SealedSecret `postgresql`, key `multica-password`
```

Connection string:
```
postgres://multica:<password>@postgresql-rw.database.svc.cluster.local:5432/multica?sslmode=require
```

## TODO

- [ ] Seal the `multica-password` in the SealedSecret once sealed-secrets controller is deployed
  ```bash
  printf '%s' 'LShFqhcsuMKO8fC6MVJ5TryHNH2y04u1dBb2EYNo2NI=' | kubeseal \
    --raw \
    --name postgresql \
    --namespace database \
    --controller-name sealed-secrets-controller \
    --controller-namespace secrets \
    --format yaml
  ```

## Design Decisions

- **Single-phase CNPG install**: Unlike mariadb-operator (2-phase CRDs + operator), CNPG's chart handles both CRDs and operator in one HelmRelease with `crds.create: true`
- **PostgreSQL 18 with standard-trixie image**: The `standard-trixie` variant from CNPG's image catalog includes pgvector pre-installed
- **Managed roles via CNPG CRs**: Uses `managed.roles` in Cluster spec and separate `Role` CR for declarative user management
- **pgvector via Database extension**: The `Database` CR declares the `vector` extension, CNPG handles installation automatically